### PR TITLE
add support for RHEL 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Ansible role for building the Nginx upload module
 
-Ansible role for building Nginx upload module from module source code and installing it into Nginx for RHEL 9 systems.
+Ansible role for building Nginx upload module from module source code and installing it into Nginx for RHEL 8 and 9 systems.
 
 This role was adapted from [nginx-upload-module](https://github.com/usegalaxy-au/infrastructure/tree/master/roles/nginx-upload-module)
 
 ### Role workflow
 
   1. Install `epel-release` package
-  2. Enable `CRB` (PowerTools) repository
+  2. Enable `CRB` (RHEL 9), and `PowerTools` (RHEL 8) repository
   3. Install `nginx` package from systems `AppStream` repository.
   4. Enable and start `nginx` service
   5. Build nginx upload module dynamically from the source code
@@ -17,11 +17,11 @@ This role was adapted from [nginx-upload-module](https://github.com/usegalaxy-au
 
 ### Requirements
 
-- Rocky Linux 9 (Should also work on RHEL 9 derivatives)
+- Rocky Linux 8 or 9
 
 #### Tested on
 
-- Rocky Linux 9
+- Rocky Linux 8 and 9
 
 ### Role Variables
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,8 +6,9 @@ galaxy_info:
   license: MIT
   min_ansible_version: 2.5
   platforms:
-  - name: EL
-    versions:
+    - name: EL
+  versions:
+    - 8
     - 9
   galaxy_tags:
     - web

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,10 +6,17 @@
     state: present
   become: true
 
+- name: Enable PowerTools repository
+  ansible.builtin.command:
+    cmd: dnf config-manager --set-enabled powertools
+  become: true
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '8'
+
 - name: Enable CRB (PowerTools) repository
   ansible.builtin.command:
     cmd: dnf config-manager --set-enabled crb
   become: true
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '9'
 
 - name: Install Nginx
   ansible.builtin.dnf:


### PR DESCRIPTION
While setting up the test instance, I discovered that RHEL 8 does not have the required upload module. After applying the below changes locally, I could test and build the upload module and load it into Nginx and able to start the service.